### PR TITLE
Present confirmation before ending stream

### DIFF
--- a/iOS/Stormtrooper/Stormtrooper/Controllers/StreamViewController.swift
+++ b/iOS/Stormtrooper/Stormtrooper/Controllers/StreamViewController.swift
@@ -307,7 +307,9 @@ class StreamViewController: UIViewController {
         // update popup with user profile picture
         FacebookDataManager.sharedInstance.fetchProfilePictureForCurrentUser { error, image in
             if let image = image {
-                popup.image = image
+                DispatchQueue.main.async {
+                    popup.image = image
+                }
             }
         }
     }


### PR DESCRIPTION
Presents the host with a confirmation to end the stream. Also calls the appropriate `endStream()` function. This PR does not change the behavior for stream _participants_, only hosts.

Should probably go through a design review before merging this in.

Closes: #193