### PR TITLE
Ensure the device supports SMS messaging

### DIFF
--- a/iOS/Stormtrooper/Stormtrooper/Controllers/InviteStreamViewController.swift
+++ b/iOS/Stormtrooper/Stormtrooper/Controllers/InviteStreamViewController.swift
@@ -95,12 +95,19 @@ class InviteStreamViewController: UIViewController {
     }
     
     func textTapped() {
+        guard MFMessageComposeViewController.canSendText() else {
+            let title = "Could Not Send SMS"
+            let message = "SMS services are not available on this device."
+            let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            let action = UIAlertAction(title: "OK", style: .default)
+            alertController.addAction(action)
+            present(alertController, animated: true)
+            return
+        }
+        
         let messageVC = MFMessageComposeViewController()
-        
         messageVC.body = "Download Together Stream to join my Stream: http://ibm.biz/BdsMEz";
-        //messageVC.recipients = [""]
         messageVC.messageComposeDelegate = self
-        
         present(messageVC, animated: true, completion: nil)
     }
     


### PR DESCRIPTION
Ensure the device supports SMS messaging. This fixes a crash in the simulator (which does not support SMS messaging) when trying to invite friends via text. This should also prevent a similar crash on any user devices without SMS.

Closes: #205.

Here's a screenshot from the simulator:

![screen shot 2017-02-02 at 12 21 44 pm](https://cloud.githubusercontent.com/assets/1957636/22562683/2e2bb702-e943-11e6-9f7f-47c6749bdb02.png)