### PR TITLE
adding new relic server monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ fastlane/test_output
 backend/node_modules
 backend/.idea
 backend/config/private
+newrelic_agent.log
+yarn.lock

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,3 +1,5 @@
+require('newrelic'); // setup new relic performance monitoring
+
 'use strict';
 
 var express = require('express');

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
     "start": "node app.js"
   },
   "dependencies": {
+    "@newrelic/native-metrics": "^2.0.2",
     "apn": "^2.1.2",
     "body-parser": "~1.15.1",
     "cfenv": "^1.0.3",
@@ -17,6 +18,7 @@
     "express-session": "^1.14.2",
     "jsonwebtoken": "^7.1.9",
     "morgan": "~1.7.0",
+    "newrelic": "^1.36.2",
     "passport": "^0.3.2",
     "passport-facebook": "^2.1.1",
     "passport-facebook-token": "^3.3.0",


### PR DESCRIPTION
closes #70 

New relic monitoring is at this URL. To be reached, you need to authenticate through bluemix. So, on open app on bluemix, then click on the new-relic service, and you should get forwarded.


Login with `cloudexperiencelab@gmail.com`’s credentials and click on the new relic link
https://console.ng.bluemix.net/services/4915058c-d318-44ea-9925-d50b3f6c2f09