### PR TITLE
Prevent nav bar from hiding when StreamViewController is not visible

### DIFF
--- a/iOS/Stormtrooper/Stormtrooper/Controllers/StreamViewController.swift
+++ b/iOS/Stormtrooper/Stormtrooper/Controllers/StreamViewController.swift
@@ -325,7 +325,7 @@ class StreamViewController: UIViewController {
     
     
     func rotated() {
-        if self.navigationController?.visibleViewController == self {
+        if navigationController?.visibleViewController == self {
             switch UIDevice.current.orientation {
             case .landscapeLeft:
                 print("Landscape Left")


### PR DESCRIPTION
This is a fix that Nathan submitted with #242. I wanted to isolate this change since that PR was rejected for other reasons.

Here's a description of the change: "fixed bug where nav bar would hide when rotating while add videos or invite friends was shown on stream."

I don't think there is an associated issue.