### PR TITLE
End refreshing on main queue

### DIFF
--- a/iOS/Stormtrooper/Stormtrooper/Controllers/HomeViewController.swift
+++ b/iOS/Stormtrooper/Stormtrooper/Controllers/HomeViewController.swift
@@ -117,7 +117,9 @@ class HomeViewController: UIViewController {
     
     @objc private func refresh(_ refreshControl: UIRefreshControl) {
         refreshStreams() {
-            refreshControl.endRefreshing()
+            DispatchQueue.main.async {
+                refreshControl.endRefreshing()
+            }
         }
     }
     


### PR DESCRIPTION
Closes #243.

Calling `endRefreshing` on the main queue seems to make the problem disappear, or at least much less frequent.

After implementing this fix, I tried refreshing the queue many times. The only trouble it ran into was one instance when the server sent an unexpected response. But even then, the refresh icon stopped spinning after the network request timed out.